### PR TITLE
Exportease/22 markdown to odt

### DIFF
--- a/md2odt-pandoc.py
+++ b/md2odt-pandoc.py
@@ -7,6 +7,7 @@ OUTPUT_DIR = 'converted_files'
 if not os.path.exists(OUTPUT_DIR):
     os.makedirs(OUTPUT_DIR)
 
+
 # Converts markdown string to an odt file and returns the filename
 def md2odt(md):
     date = datetime.datetime.now().strftime('%Y-%m-%d-%H-%M-%S')
@@ -14,13 +15,3 @@ def md2odt(md):
     output_path = os.path.join(OUTPUT_DIR, filename)
     pypandoc.convert_text(md, 'odt', format='md', outputfile=output_path)
     return filename
-
-# Example usage
-md = """
-# This is a heading
-- This is a bullet point
-- This is another bullet point
-"""
-
-filename = md2odt(md)
-print(filename)

--- a/md2odt-pandoc.py
+++ b/md2odt-pandoc.py
@@ -1,0 +1,26 @@
+import pypandoc
+import datetime
+import os
+
+# Directory to save the converted files
+OUTPUT_DIR = 'converted_files'
+if not os.path.exists(OUTPUT_DIR):
+    os.makedirs(OUTPUT_DIR)
+
+# Converts markdown string to an odt file and returns the filename
+def md2odt(md):
+    date = datetime.datetime.now().strftime('%Y-%m-%d-%H-%M-%S')
+    filename = f'markdown-{date}.odt'
+    output_path = os.path.join(OUTPUT_DIR, filename)
+    pypandoc.convert_text(md, 'odt', format='md', outputfile=output_path)
+    return filename
+
+# Example usage
+md = """
+# This is a heading
+- This is a bullet point
+- This is another bullet point
+"""
+
+filename = md2odt(md)
+print(filename)

--- a/md2pptx-pandoc.py
+++ b/md2pptx-pandoc.py
@@ -2,6 +2,7 @@ import pypandoc
 import datetime
 import os
 
+
 # Directory to save the converted files
 OUTPUT_DIR = 'converted_files'
 if not os.path.exists(OUTPUT_DIR):


### PR DESCRIPTION
**Added features:**
- Introduced the capability to convert markdown content to different formats using the `pypandoc` library:
  - `md2odt-pandoc.py`: Converts markdown content to the OpenDocument Text (ODT) format. The generated ODT file is named based on the current date and time to ensure uniqueness and is saved in a directory named `converted_files`. If the directory doesn't exist, it's created.
  - `md2pptx-pandoc.py`: Presumably, this script is set up to convert markdown content to the PowerPoint (PPTX) format, although specific details weren't provided in the diffs.

---

**Refinements:**
- Removed the demonstration code from `md2odt-pandoc.py` that showed an example of converting a simple markdown string to an ODT file.
- Minor formatting adjustments were made in both scripts for better readability.

---

Closes #22 

