### PR TITLE
Exportease/23 markdown to html

### DIFF
--- a/md2html-pandoc.py
+++ b/md2html-pandoc.py
@@ -15,11 +15,3 @@ def md2html(md):
     output_path = os.path.join(OUTPUT_DIR, filename)
     pypandoc.convert_text(md, 'html', format='md', outputfile=output_path)
     return filename
-
-example_md = """
-# This is a heading
-- This is a bullet point
-- This is another bullet point
-"""
-
-print(md2html(example_md))

--- a/md2html-pandoc.py
+++ b/md2html-pandoc.py
@@ -1,0 +1,25 @@
+import pypandoc
+import datetime
+import os
+
+# Directory to save the converted files
+OUTPUT_DIR = 'converted_files'
+if not os.path.exists(OUTPUT_DIR):
+    os.makedirs(OUTPUT_DIR)
+
+
+# Converts markdown string to an html file and returns the filename
+def md2html(md):
+    date = datetime.datetime.now().strftime('%Y-%m-%d-%H-%M-%S')
+    filename = f'markdown-{date}.html'
+    output_path = os.path.join(OUTPUT_DIR, filename)
+    pypandoc.convert_text(md, 'html', format='md', outputfile=output_path)
+    return filename
+
+example_md = """
+# This is a heading
+- This is a bullet point
+- This is another bullet point
+"""
+
+print(md2html(example_md))


### PR DESCRIPTION
**Added features:**
- Introduced the capability to convert markdown content to different formats using the `pypandoc` library:
  - `md2html-pandoc.py`: Converts markdown content to the OpenDocument Text (HTML) format. The generated HTML file is named based on the current date and time to ensure uniqueness and is saved in a directory named `converted_files`. If the directory doesn't exist, it's created.
  - `md2pptx-pandoc.py`: Presumably, this script is set up to convert markdown content to the PowerPoint (PPTX) format, although specific details weren't provided in the diffs.

---

**Refinements:**
- Removed the demonstration code from `md2html-pandoc.py` that showed an example of converting a simple markdown string to an HTML file.
- Minor formatting adjustments were made in both scripts for better readability.