### PR TITLE
Extensive Enhancements to the Markdown-to-PPTX Conversion in `md2pptx-pandoc.py`

### DIFF
--- a/md2pptx-pandoc.py
+++ b/md2pptx-pandoc.py
@@ -1,18 +1,48 @@
-import pypandoc
 import datetime
-import os
+import codecs
+import pypandoc
+from fastapi import Depends, FastAPI, Form, HTTPException, UploadFile
+from fastapi.responses import FileResponse, JSONResponse
+from pydantic import BaseModel
+from pathlib import Path
 
+app = FastAPI()
 
 # Directory to save the converted files
 OUTPUT_DIR = 'converted_files'
-if not os.path.exists(OUTPUT_DIR):
-    os.makedirs(OUTPUT_DIR)
+Path(OUTPUT_DIR).mkdir(parents=True, exist_ok=True)
 
 
-# Converts markdown string to a pptx file and returns the filename
-def md2pptx(md):
+class MarkdownRequest(BaseModel):
+    md: str
+
+
+def md2pptx(md: str) -> str:
     date = datetime.datetime.now().strftime('%Y-%m-%d-%H-%M-%S')
     filename = f'markdown-{date}.pptx'
-    output_path = os.path.join(OUTPUT_DIR, filename)
+    output_path = Path(OUTPUT_DIR) / filename
     pypandoc.convert_text(md, 'pptx', format='md', outputfile=output_path)
     return filename
+
+
+@app.post("/md2pptx")
+def convert_md2pptx(request: MarkdownRequest):
+    request.md = codecs.decode(request.md, 'unicode_escape')
+    print(f"Received markdown content: {request.md}")
+    try:
+        filename = md2pptx(request.md)
+        return {"message": "Conversion successful!", "filename": filename, "result": request.md}
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    
+
+@app.get("/download/{filename}")
+def download_file(filename: str):
+    path = Path(OUTPUT_DIR) / filename
+    headers = {"Content-Disposition": f"attachment; filename={filename}"}
+    return FileResponse(path, headers=headers)
+
+
+if __name__ == '__main__':
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8000)


### PR DESCRIPTION
1. **General Refinements**:
    - Transitioned to using the `pathlib` library for directory and file path management, replacing traditional `os` operations.
    - Utilized `Path.mkdir` for creating directories, ensuring cross-platform compatibility.

2. **New Class and Method Refactoring in `md2pptx-pandoc.py`**:
    - Introduced a new `MarkdownRequest` class to model incoming Markdown content for conversion.
    - Refactored the `md2pptx` function to accept a string argument and return a string representing the filename.

3. **Endpoint Additions and Reorganization**:
    - Added a POST endpoint `/md2pptx` to handle Markdown-to-PPTX conversions, including decoding of escaped sequences.
    - Included a GET endpoint `/download/{filename}` to facilitate downloading of the converted PPTX file.
    - Reorganized imports for better clarity and structure.

These refinements significantly enhance the functionality of the Markdown-to-PPTX conversion process, providing a clearer API structure, and utilizing modern Python libraries for improved code quality.